### PR TITLE
Revamp container component

### DIFF
--- a/manifests/containers/generic/manifest/manifest.xml
+++ b/manifests/containers/generic/manifest/manifest.xml
@@ -3,7 +3,7 @@
     This manifest defines the behavior of generic containerized components
 -->
 <manifest>
-  <project name="lcaf-component-container" path="components/container" remote="launch-dso-platform" revision="refs/heads/feature/revamp" dso_override_attribute_revision='${CONTAINER_VER}'>
+  <project name="lcaf-component-container" path="components/container" remote="launch-dso-platform" revision="refs/tags/1.0.0" dso_override_attribute_revision='${CONTAINER_VER}'>
     <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />
     <linkfile src="linkfiles/.secrets.baseline" dest=".secrets.baseline" />
   </project>

--- a/manifests/containers/generic/manifest/manifest.xml
+++ b/manifests/containers/generic/manifest/manifest.xml
@@ -3,7 +3,10 @@
     This manifest defines the behavior of generic containerized components
 -->
 <manifest>
-  <project name="lcaf-component-container" path="components/container" remote="launch-dso-platform" revision="refs/tags/1.0.0" dso_override_attribute_revision='${CONTAINER_VER}'>
-    <linkfile src="linkfiles/Makefile.container.includes" dest="Makefile.container.includes" />
+  <project name="lcaf-component-container" path="components/container" remote="launch-dso-platform" revision="refs/heads/feature/revamp" dso_override_attribute_revision='${CONTAINER_VER}'>
+    <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />
+    <linkfile src="linkfiles/.secrets.baseline" dest=".secrets.baseline" />
+  </project>
+  <project name="lcaf-component-policy" path="components/policy" remote="launch-dso-platform" revision="refs/tags/1.0.0" dso_override_attribute_revision='${POLICY_VER}'>
   </project>
 </manifest>


### PR DESCRIPTION
Fixes to go alongside the container component rework. Requires https://github.com/launchbynttdata/lcaf-component-container/pull/1 to merge and have tags bumped prior to merging this.

Adds the policy component, and binds linkfiles in the container component that were previously unused. We're not building Docker-in-Docker anymore, so we can drop the container includes.