### PR TITLE
Feature/python uv

### DIFF
--- a/manifests/python/manifest/manifest.xml
+++ b/manifests/python/manifest/manifest.xml
@@ -3,8 +3,8 @@
     This manifest defines the behavior of standalone Python components
 -->
 <manifest>
-  <project name="lcaf-component-python" path="components/python" remote="launch-dso-platform" revision="refs/heads/feature!/uv" dso_override_attribute_revision='${PYTHON_VER}'>
+  <project name="lcaf-component-python" path="components/python" remote="launch-dso-platform" revision="refs/tags/2.0.0" dso_override_attribute_revision='${PYTHON_VER}'>
     <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />
-    <linkfile src="linkfiles/.secrets.baselien" dest=".secrets.baseline" />
+    <linkfile src="linkfiles/.secrets.baseline" dest=".secrets.baseline" />
   </project>
 </manifest>

--- a/manifests/python/manifest/manifest.xml
+++ b/manifests/python/manifest/manifest.xml
@@ -3,7 +3,8 @@
     This manifest defines the behavior of standalone Python components
 -->
 <manifest>
-  <project name="lcaf-component-python" path="components/python" remote="launch-dso-platform" revision="refs/tags/1.0.0" dso_override_attribute_revision='${PYTHON_VER}'>
+  <project name="lcaf-component-python" path="components/python" remote="launch-dso-platform" revision="refs/heads/feature!/uv" dso_override_attribute_revision='${PYTHON_VER}'>
     <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />
+    <linkfile src="linkfiles/.secrets.baselien" dest=".secrets.baseline" />
   </project>
 </manifest>


### PR DESCRIPTION
Points the lcaf-component-python reference to tag [2.0.0](https://github.com/launchbynttdata/lcaf-component-python/releases/tag/2.0.0). Adds the secrets baseline file which is now available in the target repo.

This update will be tagged `1.7.0` and will not automatically be consumed by existing references to the Python module.