### PR TITLE
Use copyfile instead of linkfile

### DIFF
--- a/manifests/python/manifest/manifest.xml
+++ b/manifests/python/manifest/manifest.xml
@@ -4,7 +4,7 @@
 -->
 <manifest>
   <project name="lcaf-component-python" path="components/python" remote="launch-dso-platform" revision="refs/tags/2.0.0" dso_override_attribute_revision='${PYTHON_VER}'>
-    <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />
-    <linkfile src="linkfiles/.secrets.baseline" dest=".secrets.baseline" />
+    <copyfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />
+    <copyfile src="linkfiles/.secrets.baseline" dest=".secrets.baseline" />
   </project>
 </manifest>


### PR DESCRIPTION
This will land the specified config file from our component into the repo where `make configure` is run.

Currently, `linkfile` produces a symlink into the components directory, which is excluded in our .gitignore file. While this doesn't break git, it creates a problem where the pre-commit configuration and secrets baselines can't be updated in the context of some downstream repo, they have to be edited at the component level. This becomes a problem for the baseline secrets, as new secrets will be forgotten each time the repo is checked out and `make configure` is run again.

For our Python projects going forward, this is solved by using `copyfile` instead to place a copy of the file into the repo, rather than the symlink. This way, the pre-commit configurations and secrets baseline live on with each individual repo.

Will be tagged and released as `1.7.1`.