### PR TITLE
Bump policy manifest version

### DIFF
--- a/manifests/terraform_modules/manifest/manifest.xml
+++ b/manifests/terraform_modules/manifest/manifest.xml
@@ -10,6 +10,6 @@
     <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />
     <linkfile src="linkfiles/.golangci.yaml" dest=".golangci.yaml" />
   </project>
-  <project name="lcaf-component-policy" path="components/policy" remote="launch-dso-platform" revision="refs/tags/1.1.0" dso_override_attribute_revision='${POLICY_VER}'>
+  <project name="lcaf-component-policy" path="components/policy" remote="launch-dso-platform" revision="refs/tags/1.1.1" dso_override_attribute_revision='${POLICY_VER}'>
   </project>
 </manifest>


### PR DESCRIPTION
Requires merge and tag of https://github.com/launchbynttdata/lcaf-component-policy/pull/3 prior to merge.

Will be released as 1.8.1.